### PR TITLE
Removes RewriteBase directive from .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,7 +1,6 @@
 Options +FollowSymLinks
 <IfModule mod_rewrite.c>
 	RewriteEngine On
-	RewriteBase /
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteRule ^(.*)$ index.php?/$1 [L]


### PR DESCRIPTION
RewriteBase directive in the .htaccess was specify that life press should run at the root level of the domain. Removing this allows LifePress to run from any level.
