### PR TITLE
Better Support MySQL 5.7

### DIFF
--- a/application/models/feed_model.php
+++ b/application/models/feed_model.php
@@ -107,11 +107,18 @@ class Feed_model extends CI_Model {
      */
     public function get_active_feed_domains()
     {
-        return $this->db
+        $rows = $this->db
             ->select('feed_domain, feed_icon')
-            ->group_by('feed_domain')
+            ->distinct()
             ->get_where('feeds', array('feed_status' => 'active'))
             ->result();
+
+        $result_map = [];
+        foreach ($rows as $data) {
+            $result_map[$data->feed_domain] = $data;
+        }
+
+        return array_values($result_map);
     }
 
     /**


### PR DESCRIPTION
Mysql 5.7 prevents group by of columns that are not in the group by or are non aggregate values in the select. It essentially aims to eliminate any randomness caused when collapsing multiple rows into 1.

In this case, if a user had multiple domains per feed you couldn’t be sure which feed_icon was coming back. I updated to pull a distinct list of feed_domain and icon then manually applied group by.

Fixes MitchellMcKenna/LifePress#58
